### PR TITLE
Add skip error and statistic dialog for batch mode

### DIFF
--- a/PDFDeSecure/PDFDeSecure.cs
+++ b/PDFDeSecure/PDFDeSecure.cs
@@ -25,16 +25,28 @@ namespace PDFDeSecure
                 var Output = Args[2];
                 DirectoryInfo di = new DirectoryInfo(Input);
                 var aryFi = di.GetFiles("*.pdf");
+                var counter = 0;
+                var error = 0;
                 foreach (FileInfo fi in aryFi)
                 {
-                    outpdf = new PdfDocument(); 
-                    pdf = PdfReader.Open(fi.OpenRead(), PdfDocumentOpenMode.Import);
-                    foreach (PdfPage page in pdf.Pages)
-                    {
-                        outpdf.AddPage(page);
+                    //Skip file with errors
+                    try { 
+                        outpdf = new PdfDocument(); 
+                        pdf = PdfReader.Open(fi.OpenRead(), PdfDocumentOpenMode.Import);
+                        foreach (PdfPage page in pdf.Pages)
+                        {
+                            outpdf.AddPage(page);
+                            }
+                        outpdf.Save(new FileInfo(Output+"\\"+fi.Name).OpenWrite(), true);
+                        counter++;
                     }
-                    outpdf.Save(new FileInfo(Output+"\\"+fi.Name).OpenWrite(), true);
+                    catch(Exception ex)
+                    {
+                        error++;
+                        File.WriteAllText(Output + "\\Error-" + fi.Name + ".log", ex.ToString());
+                    }
                 }
+                MessageBox.Show("Unlocked " + counter + " files" + Environment.NewLine + "Failed " + error + " files" + Environment.NewLine + "Percentage " + counter + "/" + (counter + error) + " = " + ((float)counter/ (float)(counter + error) * 100).ToString("f2") + "%, Cheers!", "PDF file Unlocked! and Saved!" , MessageBoxButtons.OK, MessageBoxIcon.Information);
                 Environment.Exit(0);
             }
         }


### PR DESCRIPTION
Now batch mode can automatically skip file with errors (with log saved to output folder) and show a simple statistic dialog after done.
<img width="224" alt="image" src="https://user-images.githubusercontent.com/24567775/189514821-3e06c0e9-c9ea-4879-abcf-4968ecb5131b.png">
